### PR TITLE
Improve image building

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -14,22 +14,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: docker://quay.io/kpfleming/apaz-test-images:image-builder
     steps:
     - name: checkout code
       uses: actions/checkout@v2
-    - name: install buildah
-      run: |
-        . /etc/os-release
-        sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${ID^}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-        wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${ID^}_${VERSION_ID}/Release.key -O Release.key
-        sudo apt-key add - < Release.key
-        sudo apt-get --quiet=2 update
-        sudo apt-get --quiet=2 --yes install buildah
     - name: build image
-      run: tests/make_container.sh
+      run: echo "::set-env name=new_image::$(tests/make_container.sh)"
+    - name: display image name
+      run: echo ${new_image}
     - name: login to quay.io
       if: github.event_name != 'pull_request'
       run: buildah login -u="kpfleming" -p="${{ secrets.QUAY_TOKEN }}" quay.io
     - name: publish image to quay.io
       if: github.event_name != 'pull_request'
-      run: buildah push quay.io/kpfleming/apaz-test-images:pdns4.3-python3
+      run: buildah push ${new_image}

--- a/tests/make_container.sh
+++ b/tests/make_container.sh
@@ -31,3 +31,5 @@ if buildah images --quiet ${image}; then
     buildah rmi ${image}
 fi
 buildah commit --squash --rm ${c} ${image}
+
+echo ${image}


### PR DESCRIPTION
* Use a Fedora base image with buildah installed instead of installing
  buildah at run time.

* Output image name from make_container.sh so publish steps can use it

Signed-off-by: Kevin P. Fleming <kevin@km6g.us>