### PR TITLE
Add zone retrieval support

### DIFF
--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -65,6 +65,12 @@
             - '1.1.1.1'
             - '::1'
 
+    - name: check slave zone retrieval
+      pdns_auth_zone:
+        <<: *common
+        name: d3.example.
+        state: retrieve
+
     - name: check zone removal
       pdns_auth_zone:
         <<: *common


### PR DESCRIPTION
This patch adds the 'retrieve' state which can be used to request
an AXFR retrieval of a zone from its master server.

Signed-off-by: Kevin P. Fleming <kevin@km6g.us>